### PR TITLE
Analytics Update

### DIFF
--- a/src/features/courses/admin/analytics/Analytics.tsx
+++ b/src/features/courses/admin/analytics/Analytics.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useGetAnalyticsQuery } from "@/redux/api-slices/apiSlice";
+import LoadingPage from "@/pages/user/LoadingPage";
 
 const Analytics: React.FC = () => {
   const { data: analyticsData, isLoading, error } = useGetAnalyticsQuery();
@@ -7,7 +8,7 @@ const Analytics: React.FC = () => {
   console.log(analyticsData);
 
   if (isLoading) {
-    return <div>Loading...</div>;
+    return <LoadingPage />;
   }
 
   if (error) {

--- a/src/pages/admin/AdminDashboard.tsx
+++ b/src/pages/admin/AdminDashboard.tsx
@@ -33,7 +33,7 @@ const AdminDashboard = () => {
       >
         <AdminHeader />
         <Routes>
-          <Route path="/" element={<div>Admin Home</div>} />
+          <Route path="/" element={<Analytics />} />
           <Route path="analytics/usage" element={<Analytics />} />
           <Route path="course/edit" element={<ManageCourse />} />
           <Route path="courses/create" element={<CreateCourse />} />


### PR DESCRIPTION
# Introduce Loading Page to Analytics/App Usage and Set as Default for Admin Login

This pull request introduces a new feature: a loading page for the Analytics/App Usage section of our application. This enhancement improves the user experience by providing visual feedback while data is being fetched.

Additionally, I have updated the application's behavior for admin users. Now, upon login, admin users are directed by default to this Analytics/App Usage page. This change ensures that key usage data is immediately accessible to our administrators, streamlining their workflow.